### PR TITLE
Add configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,27 @@ npm install haml-coffee-browserify
 $ browserify -t haml-coffee-browserify foo.hamlc > bundle.js
 ```
 
+# Configuration
+
+You can configure the Hamlc compiler through package.json, under a `haml-coffee-browserify` key.
+Check out Hamlc [Compiler Options](https://github.com/netzpirat/haml-coffee#compiler-options) and [Custom Helper Function Options](https://github.com/netzpirat/haml-coffee#custom-helper-function-options) for more info
+
+For example:
+```
+  "haml-coffee-browserify": {
+    "compilerOptions": {
+      "customHtmlEscape": "window.HAML.escape",
+      "customPreserve": "window.HAML.preserve",
+      "customCleanValue": "window.HAML.cleanValue",
+      "customSurround": "window.HAML.surround",
+      "customSucceed": "window.HAML.succeed",
+      "customPrecede": "window.HAML.precede",
+      "customReference": "window.HAML.reference",
+      "context": "window.HAML.context"
+    }
+  }
+```
+
 # License
 
 MIT

--- a/lib/haml-coffee-browserify.js
+++ b/lib/haml-coffee-browserify.js
@@ -1,9 +1,22 @@
 var through      = require('through'),
+    mothership   = require('mothership'),
+    path         = require('path'),
     CoffeeScript = require('coffee-script');
 
 require('coffee-script/register');
 
-var HamlCompiler = require('haml-coffee/src/haml-coffee');
+var HamlCompiler  = require('haml-coffee/src/haml-coffee');
+
+var configPackage = mothership.sync(__dirname, function (pack) {
+      return !!pack["haml-coffee-browserify"];
+    }),
+    config;
+
+if (configPackage) {
+  config = configPackage.pack["haml-coffee-browserify"];
+} else {
+  config = {};
+}
 
 /**
  * Browserify plugin to convert haml-coffee (.hamlc) templates to Javascript.
@@ -36,7 +49,8 @@ var HamlCoffeeBrowserify = {
 
     // end the process
     function end () {
-      var options  = {},
+      var options  = config.compilerOptions || {},
+          context  = options.context,
           compiler = new HamlCompiler(options),
           template,
           compiled;
@@ -51,10 +65,14 @@ var HamlCoffeeBrowserify = {
       );
 
       compiled = "module.exports = function(options) {\n" +
-        "return (function() {\n" +
-        template + "\n" +
-        "}).call(options)\n" +
-        "};";
+      "return (function() {\n" +
+      template + "\n" +
+      "}).call(options);\n" +
+      "};";
+
+      if (context) {
+        compiled = compiled.replace('.call(options);', '.call(' + context + '(options));');
+      }
 
       stream.queue(compiled);
 

--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
   },
   "homepage": "https://github.com/scottbrady/haml-coffee-browserify",
   "dependencies": {
-    "haml-coffee" : "~1.14.1",
     "coffee-script": "~1.8.0",
+    "haml-coffee": "~1.14.1",
+    "mothership": "^0.3.0",
     "through": "~2.3.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
     "name": "Scott Brady",
     "email": "scott@sbrady.com"
   },
+  "contributors": [
+    {
+      "name": "Stratos Pavlakis",
+      "email": "pavlakis.stratos@gmail.com"
+    }
+  ],
   "keywords": [
     "haml",
     "coffee",


### PR DESCRIPTION
Hi Scott, and thanks for this browserify plugin.

This PR adds Hamlc compiler configuration support through package.json 
Configuring the compiler with helper functions is something encouraged by its authors and reduces the assets size which is important for mobile.

Thx
